### PR TITLE
Updated to traceview terminology.

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,9 +1,9 @@
-name    'puppet-tracelytics'
-version '0.0.1'
+name    'puppet-taceview'
+version '0.0.2'
 author 'pdrakeweb'
 license 'GPL'
-summary 'Installs tracelytics instrumentation.'
-description 'Installs and configures tracelytics instrumentation.'
+summary 'Installs traceview instrumentation.'
+description 'Installs and configures traceview instrumentation.'
 project_page 'https://github.com/pdrakeweb/puppet-tracelytics'
 
 ## Add dependencies, if any:

--- a/README
+++ b/README
@@ -1,3 +1,1 @@
-tracelytics
-
-This is the tracelytics module.
+A traceview (formerly tracelytics) module for puppet.

--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -1,20 +1,20 @@
-class tracelytics::apache($apache_tracing_mode = "always", $apache_sampling_rate = 300000) {
+class traceview::apache($apache_tracing_mode = "always", $apache_sampling_rate = 300000) {
 
-  include tracelytics
+  include traceview
 
-  $tracing_mode = hiera('tracelytics_tracing_mode', $apache_tracing_mode)
-  $sampling_rate = hiera('tracelytics_sampling_rate', $apache_sampling_rate)
+  $tracing_mode = hiera('traceview_tracing_mode', $apache_tracing_mode)
+  $sampling_rate = hiera('traceview_sampling_rate', $apache_sampling_rate)
 
   package { "libapache2-mod-oboe":
     ensure  => installed,
-    require => [ Package["liboboe0"], Apt::Source["tracelytics"], Package["apache2"] ],
+    require => [ Package["liboboe0"], Apt::Source["traceview"], Package["apache2"] ],
   }
 
   file { "/etc/apache2/mods-available/oboe.conf":
     owner   => root,
     group   => root,
     mode    => 644,
-    content => template('tracelytics/oboe.conf.erb'),
+    content => template('traceview/oboe.conf.erb'),
     require => Package["libapache2-mod-oboe"],
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,33 +1,33 @@
-class tracelytics {
+class traceview {
 
   include apt
 
-  $access_key = hiera('tracelytics_access_key', 'access_key')
-  
+  $access_key = hiera('traceview_access_key', 'access_key')
+
   package { "liboboe0":
     ensure  => installed,
-    require => Apt::Source["tracelytics"],
+    require => Apt::Source["traceview"],
   }
 
   package { "liboboe-dev":
     ensure  => installed,
-    require => [ Package["liboboe0"], Apt::Source["tracelytics"] ],
+    require => [ Package["liboboe0"], Apt::Source["traceview"] ],
   }
 
   package { "tracelyzer":
     ensure  => installed,
-    require => [ Package["liboboe0"], Apt::Source["tracelytics"] ],
+    require => [ Package["liboboe0"], Apt::Source["traceview"] ],
   }
 
   file { "/etc/tracelytics.conf":
     owner   => root,
     group   => root,
     mode    => 644,
-    content => template("tracelytics/tracelytics.conf.erb"),
+    content => template("traceview/tracelytics.conf.erb"),
     replace => false,
   }
 
-  apt::source { "tracelytics":
+  apt::source { "traceview":
     location    => "http://apt.tracelytics.com/${access_key}",
     release     => "${lsbdistcodename}",
     repos       => "main",

--- a/manifests/java.pp
+++ b/manifests/java.pp
@@ -1,15 +1,15 @@
-class tracelytics::java {
+class traceview::java {
 
-  include tracelytics
+  include traceview
 
   package { "tracelytics-java-agent":
     ensure  => installed,
-    require => [ Package["liboboe0"], Apt::Source["tracelytics"] ],
+    require => [ Package["liboboe0"], Apt::Source["traceview"] ],
   }
 
   package { "tracelytics-java-agent-native":
     ensure  => installed,
-    require => [ Package["liboboe0"], Apt::Source["tracelytics"] ],
+    require => [ Package["liboboe0"], Apt::Source["traceview"] ],
   }
 
 }

--- a/manifests/libcurl.pp
+++ b/manifests/libcurl.pp
@@ -1,10 +1,10 @@
-class tracelytics::libcurl {
+class traceview::libcurl {
 
-  include tracelytics
+  include traceview
 
   package { "libcurl3":
     ensure  => '7.22.0-3ubuntu4+tracelytics2',
-    require => [ Package["liboboe0"], Apt::Source["tracelytics"] ],
+    require => [ Package["liboboe0"], Apt::Source["traceview"] ],
   }
 
 }

--- a/manifests/nginx.pp
+++ b/manifests/nginx.pp
@@ -1,15 +1,15 @@
-class tracelytics::nginx($nginx_tracing_mode = "always", $nginx_sampling_rate = 300000) {
+class traceview::nginx($nginx_tracing_mode = "always", $nginx_sampling_rate = 300000) {
 
-  include tracelytics
+  include traceview
 
-  $tracing_mode = hiera('tracelytics_tracing_mode', $nginx_tracing_mode)
-  $sampling_rate = hiera('tracelytics_sampling_rate', $nginx_sampling_rate)
+  $tracing_mode = hiera('traceview_tracing_mode', $nginx_tracing_mode)
+  $sampling_rate = hiera('traceview_sampling_rate', $nginx_sampling_rate)
 
   file { "/etc/nginx/conf.d/oboe.conf":
     owner   => root,
     group   => root,
     mode    => 644,
-    content => template('tracelytics/nginx.oboe.conf.erb'),
+    content => template('traceview/nginx.oboe.conf.erb'),
     require => Package['nginx-extras'],
     notify  => Service['nginx'],
   }

--- a/manifests/php.pp
+++ b/manifests/php.pp
@@ -1,10 +1,10 @@
-class tracelytics::php {
+class traceview::php {
 
-  include tracelytics
+  include traceview
 
   package { "php-oboe":
     ensure  => installed,
-    require => [ Package["liboboe0"], Apt::Source["tracelytics"] ],
+    require => [ Package["liboboe0"], Apt::Source["traceview"] ],
   }
 
 }

--- a/manifests/python.pp
+++ b/manifests/python.pp
@@ -1,6 +1,6 @@
-class tracelytics::python {
+class traceview::python {
 
-  include tracelytics
+  include traceview
 
   if !defined(Package["python"]) {
     package { "python":

--- a/manifests/ruby.pp
+++ b/manifests/ruby.pp
@@ -1,14 +1,14 @@
-class tracelytics::ruby {
+class traceview::ruby {
 
-  package { "oboe": 
-    ensure    => installed, 
+  package { "oboe":
+    ensure    => installed,
     provider  => gem,
     source    => "http://gem.tracelytics.com/",
     require   => [ Package["rubygems"], Package["liboboe-dev"]],
   }
 
-  package { "oboe_fu": 
-    ensure    => installed, 
+  package { "oboe_fu":
+    ensure    => installed,
     provider  => gem,
     source    => "http://gem.tracelytics.com/",
     require   => [ Package["rubygems"], Package["liboboe-dev"] ],

--- a/templates/nginx.oboe.conf.erb
+++ b/templates/nginx.oboe.conf.erb
@@ -1,6 +1,6 @@
-# Tracelytics Oboe instrumentation module for Nginx configuration
+# Traceview Oboe instrumentation module for Nginx configuration
 # for help tuning, please visit
-# http://support.tracelytics.com/kb/configuration/configuring-nginx
+# https://support.tv.appneta.com/support/solutions/articles/86387-configuring
 
 # oboe_tracing_mode: When traces should be initiated for incoming
 # requests. Valid options are "always", "through", and "never".

--- a/templates/oboe.conf.erb
+++ b/templates/oboe.conf.erb
@@ -1,6 +1,6 @@
-# Tracelytics oboe instrumentation module for Apache configuration
+# Traceview oboe instrumentation module for Apache configuration
 # for help tuning, please visit
-# http://support.tracelytics.com/kb/configuration/configuring-apache
+# https://support.tv.appneta.com/support/solutions/articles/86398-configuring
 
 <IfModule mod_oboe.c>
     # OboeTracingMode: When traces should be initiated for incoming

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -1,1 +1,1 @@
-include tracelytics
+include traceview


### PR DESCRIPTION
Tracelytics has been Traceview for nearly two years now, it's time to change the terminology to reflect that. This pull request changes everything that can be changed, there are some configurations and package names that still reflect Tracelytics.
